### PR TITLE
return empty node label if worker doesn't have props

### DIFF
--- a/nodeLabelWorker.js
+++ b/nodeLabelWorker.js
@@ -73,6 +73,10 @@ function nodeLabelWorker({ node, network }) {
   // For our example worker we will return a different label dependant on the node type.
   let label = node.nickname || node.name;
 
+  if (!label) {
+    return false;
+  }
+
   switch (node.networkCanvasType) {
     case 'person':
       if (network.edges.some(


### PR DESCRIPTION
fixes issue where nodes from the external CSV would show "null" instead of correct label.